### PR TITLE
Fix removal of existing labels

### DIFF
--- a/src/merge-labels.js
+++ b/src/merge-labels.js
@@ -1,0 +1,22 @@
+module.exports = mergeLabels;
+
+function mergeLabels({ existingLabels, labelsToAdd, labelsToRemove, robot}) {
+  const finalLabelsList = new Set(existingLabels);
+  let hasChanges = false;
+
+  if (labelsToRemove.length > 0) {
+    robot.log('Removing labels', labelsToRemove);
+    hasChanges = true;
+    for (let label of labelsToRemove) {
+      finalLabelsList.delete(label);
+    }
+  }
+  if (labelsToAdd.length > 0) {
+    robot.log('Adding labels', labelsToAdd);
+    hasChanges = true;
+    for (let label of labelsToAdd) {
+      finalLabelsList.add(label);
+    }
+  }
+  return { hasChanges, finalLabelsList };
+}

--- a/test/determine-labels.test.js
+++ b/test/determine-labels.test.js
@@ -228,4 +228,15 @@ describe('determineLabels()', () => {
     }).labelsToAdd).toEqual(['xs', 'sm']);
   });
 
+  test('does not remove existing labels not in the config', () => {
+    const { labelsToRemove } = determineLabels({
+      ...defaultParams(),
+      existingLabels: new Set(['xs', 'other-label']),
+      additions: 0,
+      deletions: 0,
+    });
+
+    expect(labelsToRemove).toEqual(['xs']);
+  });
+
 });

--- a/test/merge-labels.test.js
+++ b/test/merge-labels.test.js
@@ -1,0 +1,58 @@
+const mergeLabels = require('../src/merge-labels');
+
+describe('mergeLabels()', () => {
+  let logLines = [];
+
+  const defaultParams = () => {
+    // reset logLines array
+    logLines = [];
+    return {
+      robot: {
+        log(...args) {
+          logLines.push(args);
+        }
+      },
+      existingLabels: new Set(),
+      labelsToAdd: [],
+      labelsToRemove: [],
+    };
+  };
+
+  test('should not remove existing labels not in the remove list', () => {
+    const { finalLabelsList } = mergeLabels({
+      ...defaultParams(),
+      existingLabels: new Set(['foo', 'baz']),
+      labelsToAdd: ['bar'],
+      labelsToRemove: ['baz'],
+    });
+
+    expect(Array.from(finalLabelsList)).toEqual(['foo', 'bar']);
+  });
+
+  test('should return hasChanges: false if nothing changed', () => {
+    const { hasChanges } = mergeLabels({
+      ...defaultParams(),
+      existingLabels: new Set(['foo', 'bar']),
+    });
+    expect(hasChanges).toBe(false);
+  });
+
+  test('should return hasChanges: true if a label was added', () => {
+    const { hasChanges } = mergeLabels({
+      ...defaultParams(),
+      existingLabels: new Set(['foo', 'bar']),
+      labelsToAdd: ['baz'],
+    });
+    expect(hasChanges).toBe(true);
+  });
+
+  test('should return hasChanges: true if a label was removed', () => {
+    const { hasChanges } = mergeLabels({
+      ...defaultParams(),
+      existingLabels: new Set(['foo', 'bar']),
+      labelsToRemove: ['bar'],
+    });
+    expect(hasChanges).toBe(true);
+  });
+  
+});


### PR DESCRIPTION
## The bug

Existing labels on a PR would be removed when sizelabeler ran.

## The cause

I was using the `removeLabels()` method which actually removed all labels on the PR, not just the ones I specified.

## The fix

Change to create an updated list of the labels the PR should have, and use `replaceLabels()` to set it.